### PR TITLE
Fix/v5 android ios compatibility

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -2,12 +2,15 @@ cmake_minimum_required(VERSION 3.10)
 project(VisionCameraOcr)
 
 add_library(VisionCameraOcr SHARED
-  OcrNativeHelper.cpp
+  src/main/cpp/OcrNativeHelper.cpp
 )
 
 # Include Nitrogen generated files
 include(${CMAKE_SOURCE_DIR}/../nitrogen/generated/android/VisionCameraOcr+autolinking.cmake)
 
 find_library(android-lib android)
+
+# Android 15+ requires 16KB page size alignment for loaded .so files
+target_link_options(VisionCameraOcr PRIVATE "-Wl,-z,max-page-size=16384" "-Wl,-z,common-page-size=16384")
 
 target_link_libraries(VisionCameraOcr ${android-lib})

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,11 @@ buildscript {
 }
 
 
+def reactNativeArchitectures() {
+  def value = project.getProperties().get("reactNativeArchitectures")
+  return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -40,19 +45,21 @@ android {
     externalNativeBuild {
       cmake {
         cppFlags "-O2 -fexceptions -frtti -std=c++20"
-        arguments "-DANDROID_STL=c++_shared"
+        abiFilters (*reactNativeArchitectures())
+        arguments "-DANDROID_STL=c++_shared", "-DANDROID_PLATFORM=android-29"
       }
     }
   }
 
   externalNativeBuild {
     cmake {
-      path "src/main/cpp/CMakeLists.txt"
+      path "CMakeLists.txt"
     }
   }
 
   buildFeatures {
     buildConfig true
+    prefab true
   }
 
   buildTypes {

--- a/android/src/main/cpp/OcrNativeHelper.cpp
+++ b/android/src/main/cpp/OcrNativeHelper.cpp
@@ -1,15 +1,66 @@
 #include <jni.h>
+#include <cstring>
 #include <android/hardware_buffer.h>
-#include <android/hardware_buffer_jni.h>
+#include "VisionCameraOcrOnLoad.hpp"
+
+// Register Nitro HybridObjects on library load
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*) {
+  return margelo::nitro::visioncameraocr::initialize(vm);
+}
 
 extern "C" {
 
-JNIEXPORT jobject JNICALL
-Java_com_bearblock_visioncameraocr_OcrNativeHelper_pointerToHardwareBuffer(
-    JNIEnv* env, jclass, jlong pointer) {
-#if __ANDROID_API__ >= 26
-  auto* hardwareBuffer = reinterpret_cast<AHardwareBuffer*>(pointer);
-  return AHardwareBuffer_toHardwareBuffer(env, hardwareBuffer);
+// Convert YUV HardwareBuffer to NV21 byte array for ML Kit.
+// Bitmap.wrapHardwareBuffer produces a HARDWARE-config bitmap that ML Kit cannot process,
+// so we lock the YUV planes directly and convert to NV21.
+JNIEXPORT jbyteArray JNICALL
+Java_com_bearblock_visioncameraocr_OcrNativeHelper_hardwareBufferToNv21(
+    JNIEnv* env, jclass, jlong pointer, jint width, jint height) {
+#if __ANDROID_API__ >= 29
+  auto* buffer = reinterpret_cast<AHardwareBuffer*>(pointer);
+
+  AHardwareBuffer_Planes planes;
+  int result = AHardwareBuffer_lockPlanes(buffer,
+      AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN, -1, nullptr, &planes);
+
+  if (result != 0) return nullptr;
+
+  int ySize = width * height;
+  int nv21Size = ySize + (width * height / 2);
+
+  jbyteArray nv21 = env->NewByteArray(nv21Size);
+  if (nv21 == nullptr) {
+    AHardwareBuffer_unlock(buffer, nullptr);
+    return nullptr;
+  }
+
+  auto* dst = env->GetByteArrayElements(nv21, nullptr);
+
+  // Copy Y plane (row by row to handle stride != width)
+  auto* yData = static_cast<uint8_t*>(planes.planes[0].data);
+  uint32_t yRowStride = planes.planes[0].rowStride;
+  for (int row = 0; row < height; row++) {
+    memcpy(dst + row * width, yData + row * yRowStride, width);
+  }
+
+  // Copy UV as interleaved VU (NV21 format)
+  auto* uData = static_cast<uint8_t*>(planes.planes[1].data);
+  auto* vData = static_cast<uint8_t*>(planes.planes[2].data);
+  uint32_t uvRowStride = planes.planes[1].rowStride;
+  uint32_t uvPixelStride = planes.planes[1].pixelStride;
+
+  int uvOffset = ySize;
+  for (int row = 0; row < height / 2; row++) {
+    for (int col = 0; col < width / 2; col++) {
+      dst[uvOffset++] = static_cast<jbyte>(vData[row * uvRowStride + col * uvPixelStride]);
+      dst[uvOffset++] = static_cast<jbyte>(uData[row * uvRowStride + col * uvPixelStride]);
+    }
+  }
+
+  env->ReleaseByteArrayElements(nv21, dst, 0);
+  AHardwareBuffer_unlock(buffer, nullptr);
+
+  return nv21;
 #else
   return nullptr;
 #endif

--- a/android/src/main/java/com/bearblock/visioncameraocr/OcrNativeHelper.kt
+++ b/android/src/main/java/com/bearblock/visioncameraocr/OcrNativeHelper.kt
@@ -1,11 +1,9 @@
 package com.bearblock.visioncameraocr
 
-import android.hardware.HardwareBuffer
-
 object OcrNativeHelper {
   init {
     System.loadLibrary("VisionCameraOcr")
   }
 
-  external fun pointerToHardwareBuffer(pointer: Long): HardwareBuffer?
+  external fun hardwareBufferToNv21(pointer: Long, width: Int, height: Int): ByteArray?
 }

--- a/android/src/main/java/com/bearblock/visioncameraocr/VisionCameraOcrPackage.kt
+++ b/android/src/main/java/com/bearblock/visioncameraocr/VisionCameraOcrPackage.kt
@@ -1,0 +1,19 @@
+package com.bearblock.visioncameraocr
+
+import com.facebook.react.BaseReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.module.model.ReactModuleInfoProvider
+import com.margelo.nitro.visioncameraocr.VisionCameraOcrOnLoad
+
+class VisionCameraOcrPackage : BaseReactPackage() {
+  override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? = null
+
+  override fun getReactModuleInfoProvider(): ReactModuleInfoProvider = ReactModuleInfoProvider { HashMap() }
+
+  companion object {
+    init {
+      VisionCameraOcrOnLoad.initializeNative()
+    }
+  }
+}

--- a/android/src/main/java/com/margelo/nitro/visioncameraocr/HybridOcrProcessor.kt
+++ b/android/src/main/java/com/margelo/nitro/visioncameraocr/HybridOcrProcessor.kt
@@ -1,7 +1,5 @@
-package com.bearblock.visioncameraocr
+package com.margelo.nitro.visioncameraocr
 
-import android.graphics.Bitmap
-import android.graphics.ColorSpace
 import android.graphics.Rect
 import android.util.Log
 import com.google.android.gms.tasks.Tasks
@@ -9,12 +7,7 @@ import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.text.Text
 import com.google.mlkit.vision.text.TextRecognition
 import com.google.mlkit.vision.text.latin.TextRecognizerOptions
-import com.margelo.nitro.visioncameraocr.HybridOcrProcessorSpec
-import com.margelo.nitro.visioncameraocr.OcrBlock
-import com.margelo.nitro.visioncameraocr.OcrBox
-import com.margelo.nitro.visioncameraocr.OcrLine
-import com.margelo.nitro.visioncameraocr.OcrResult
-import com.margelo.nitro.visioncameraocr.OcrWord
+import com.bearblock.visioncameraocr.OcrNativeHelper
 
 class HybridOcrProcessor : HybridOcrProcessorSpec() {
   private val recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
@@ -23,7 +16,7 @@ class HybridOcrProcessor : HybridOcrProcessorSpec() {
     get() = 128
 
   override fun performOcr(
-    bufferAddress: Double,
+    bufferAddress: ULong,
     width: Double,
     height: Double,
     orientation: String,
@@ -32,24 +25,13 @@ class HybridOcrProcessor : HybridOcrProcessorSpec() {
     recognitionLevel: String
   ): OcrResult? {
     return try {
-      val pointer = bufferAddress.toLong()
-      val hardwareBuffer = OcrNativeHelper.pointerToHardwareBuffer(pointer)
+      val w = width.toInt()
+      val h = height.toInt()
+
+      val nv21 = OcrNativeHelper.hardwareBufferToNv21(bufferAddress.toLong(), w, h)
         ?: return null
 
-      val bitmap = Bitmap.wrapHardwareBuffer(hardwareBuffer, ColorSpace.get(ColorSpace.Named.SRGB))
-      hardwareBuffer.close()
-
-      if (bitmap == null) return null
-
-      val rotationDegrees = when (orientation) {
-        "up" -> 0
-        "right" -> 90
-        "down" -> 180
-        "left" -> 270
-        else -> 0
-      }
-
-      val inputImage = InputImage.fromBitmap(bitmap, rotationDegrees)
+      val inputImage = InputImage.fromByteArray(nv21, w, h, 90, InputImage.IMAGE_FORMAT_NV21)
       val visionText: Text = Tasks.await(recognizer.process(inputImage))
 
       if (visionText.text.isEmpty()) return null

--- a/ios/HybridOcrProcessor.swift
+++ b/ios/HybridOcrProcessor.swift
@@ -4,11 +4,10 @@ import CoreImage
 import NitroModules
 
 class HybridOcrProcessor: HybridOcrProcessorSpec {
-  var hybridContext = margelo.nitro.HybridContext()
-  var memorySize: Int { return getSizeOf(self) }
+  var memorySize: Int { return 0 }
 
   func performOcr(
-    bufferAddress: Double,
+    bufferAddress: UInt64,
     width: Double,
     height: Double,
     orientation: String,
@@ -16,25 +15,17 @@ class HybridOcrProcessor: HybridOcrProcessorSpec {
     includeConfidence: Bool,
     recognitionLevel: String
   ) throws -> OcrResult? {
-    let pointer = UInt(bufferAddress)
+    let pointer = UInt(truncatingIfNeeded: bufferAddress)
     guard let rawPointer = UnsafeRawPointer(bitPattern: pointer) else {
       return nil
     }
     let pixelBuffer = Unmanaged<CVPixelBuffer>.fromOpaque(rawPointer).takeUnretainedValue()
 
-    guard let ciImage = CIImage(cvPixelBuffer: pixelBuffer) else {
-      return nil
-    }
-
-    let cgOrientation = mapOrientation(orientation)
-    let handler = VNImageRequestHandler(ciImage: ciImage, orientation: cgOrientation, options: [:])
+    let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+    let handler = VNImageRequestHandler(ciImage: ciImage, orientation: .right, options: [:])
 
     let request = VNRecognizeTextRequest()
-    if recognitionLevel == "accurate" {
-      request.recognitionLevel = .accurate
-    } else {
-      request.recognitionLevel = .fast
-    }
+    request.recognitionLevel = recognitionLevel == "accurate" ? .accurate : .fast
 
     try handler.perform([request])
 
@@ -78,15 +69,5 @@ class HybridOcrProcessor: HybridOcrProcessorSpec {
     )
 
     return OcrResult(text: joinedText, blocks: [block])
-  }
-
-  private func mapOrientation(_ orientation: String) -> CGImagePropertyOrientation {
-    switch orientation {
-    case "up": return .up
-    case "down": return .down
-    case "left": return .left
-    case "right": return .right
-    default: return .up
-    }
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,7 +53,7 @@ export function performOcr(
 ): import('./specs/OcrProcessor.nitro').OcrResult | null {
   'worklet';
   const result = ocrProcessor.performOcr(
-    Number(bufferPointer),
+    BigInt(bufferPointer),
     width,
     height,
     orientation,

--- a/src/specs/OcrProcessor.nitro.ts
+++ b/src/specs/OcrProcessor.nitro.ts
@@ -1,4 +1,4 @@
-import type { HybridObject } from 'react-native-nitro-modules';
+import type { HybridObject, UInt64 } from 'react-native-nitro-modules';
 
 export interface OcrBox {
   x: number;
@@ -34,7 +34,7 @@ export interface OcrResult {
 export interface OcrProcessor
   extends HybridObject<{ ios: 'swift'; android: 'kotlin' }> {
   performOcr(
-    bufferAddress: number,
+    bufferAddress: UInt64,
     width: number,
     height: number,
     orientation: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1538,16 +1538,15 @@ __metadata:
     react-native: 0.79.2
     react-native-builder-bob: ^0.40.11
     react-native-nitro-modules: ^0.35.10
-    react-native-vision-camera: ^4.6.4
-    react-native-worklets-core: ^1.5.0
+    react-native-vision-camera: ^5.0.0
     release-it: ^17.10.0
     turbo: ^1.10.7
     typescript: ^5.8.3
   peerDependencies:
     react: "*"
     react-native: "*"
-    react-native-vision-camera: ">= 3"
-    react-native-worklets-core: ^1.5.0
+    react-native-nitro-modules: ">= 0.27.0"
+    react-native-vision-camera: ">= 5.0.0"
   languageName: unknown
   linkType: soft
 
@@ -10419,35 +10418,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-vision-camera@npm:^4.6.4":
-  version: 4.6.4
-  resolution: "react-native-vision-camera@npm:4.6.4"
-  peerDependencies:
-    "@shopify/react-native-skia": "*"
-    react: "*"
-    react-native: "*"
-    react-native-reanimated: "*"
-    react-native-worklets-core: "*"
-  peerDependenciesMeta:
-    "@shopify/react-native-skia":
-      optional: true
-    react-native-reanimated:
-      optional: true
-    react-native-worklets-core:
-      optional: true
-  checksum: abcbb23fbc0488bece5e8c4f1732728f94ca8ab4cf4b77a3f8be5eadd6c27a1bbe3b374bcd2239773e284bd548bd644658e43c1869fdb228410ba4d86aa49e8d
-  languageName: node
-  linkType: hard
-
-"react-native-worklets-core@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "react-native-worklets-core@npm:1.5.0"
-  dependencies:
-    string-hash-64: ^1.0.3
+"react-native-vision-camera@npm:^5.0.0":
+  version: 5.2.2
+  resolution: "react-native-vision-camera@npm:5.2.2"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 36c7353ceeb7cdd3a56c9d765a940b4b59b4a16549edf14e444292baa629b60fd284021a9db73a764a555d1ac03a1ca9b27ff328ed3d671a4bc6ff8cfbc079cf
+    react-native-nitro-image: "*"
+    react-native-nitro-modules: "*"
+  checksum: 1661cbc79721b5a7c097d5ea9fff3725eb30e20ca0bc28164cf475dbe2142aa8071e1a7e02ee940a13939da2c87d6ee6db7cf1571f85405eeac991059c8b20b1
   languageName: node
   linkType: hard
 
@@ -11436,13 +11415,6 @@ __metadata:
     es-errors: ^1.3.0
     internal-slot: ^1.1.0
   checksum: be944489d8829fb3bdec1a1cc4a2142c6b6eb317305eeace1ece978d286d6997778afa1ae8cb3bd70e2b274b9aa8c69f93febb1e15b94b1359b11058f9d3c3a1
-  languageName: node
-  linkType: hard
-
-"string-hash-64@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "string-hash-64@npm:1.0.3"
-  checksum: 79de8431b4fa3e85a2429cd52a34f7948221ff167b7a094e05d6bcfd0173474b232e0c9845c96f74b0d7b6b0c8bbe2c3532a4cacb21635293ef0cf3cc8e77f06
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

The `5.0.0-beta.1` release contains two blocking issues that prevent it from working with VisionCamera v5.

**iOS**
- Build fails due to the removed `margelo.nitro.HybridContext()` and `getSizeOf()` APIs.
- Uses an incorrect `guard let` on `CIImage(cvPixelBuffer:)`, which is non-optional.

**Android**
- `Bitmap.wrapHardwareBuffer` produces a `Bitmap.Config.HARDWARE` bitmap, which ML Kit cannot process, causing OCR to silently fail at runtime.

## Changes

- Replaced `Bitmap.wrapHardwareBuffer` with direct YUV plane access via `AHardwareBuffer_lockPlanes`, converting the image to an NV21 byte array for ML Kit.
- Removed broken `HybridContext` and `getSizeOf` references on iOS.
- Changed `bufferAddress` from `number`/`Double` to `UInt64`/`ULong` across the Nitro bridge, since pointer values can exceed the signed integer range.
- Added `JNI_OnLoad` for proper Nitro `HybridObject` registration on Android.
- Added `VisionCameraOcrPackage` for React Native autolinking.
- Moved `CMakeLists.txt` to the Android root for correct Nitrogen path resolution.
- Added 16 KB page size linker flags (required for Android 15+).
- Set `ANDROID_PLATFORM=android-29` (required for `AHardwareBuffer_lockPlanes`).
- Regenerated Nitrogen bindings using `npx nitrogen`.

## Tested On

- iOS (physical device)
- Android (physical device)