### PR TITLE
fix(android): store options as class property in OcrFrameProcessorPlugin

### DIFF
--- a/android/src/main/java/com/bearblock/visioncameraocr/visioncameraocr/OcrFrameProcessorPlugin.kt
+++ b/android/src/main/java/com/bearblock/visioncameraocr/visioncameraocr/OcrFrameProcessorPlugin.kt
@@ -18,7 +18,7 @@ import java.util.HashMap
 
 class OcrFrameProcessorPlugin(
   proxy: VisionCameraProxy,
-  options: Map<String, Any>?
+  private val options: Map<String, Any>?
 ) : FrameProcessorPlugin() {
 
   private val recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)


### PR DESCRIPTION
## Summary
- Fixes a regression of #2 that came back during the v4 rewrite: `options` was declared as a plain constructor parameter (no `val`) but referenced inside `callback()`, which Kotlin does not allow. This causes `OcrFrameProcessorPlugin.kt` to fail with `Unresolved reference 'options'` on Android builds, exactly as originally reported in #2.
- `OcrFrameProcessorPluginRegistry.kt` already calls `OcrFrameProcessorPlugin(proxy, options)` with two arguments, so the constructor needs to accept and store `options` — this change adds `private val` to make it a class property.

Fixes #2

## Test plan
- [ ] Run an Android build (`./gradlew :bear-block_vision-camera-ocr:compileDebugKotlin` or equivalent in an example app) to confirm the plugin compiles.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HYY4YSxCBLwZaLQKZVRUuZ)_