### PR TITLE
ci: add npm publish workflow triggered by GitHub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish to npm
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to publish (e.g. v4.0.1)'
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build package
+        run: yarn prepare
+
+      - name: Sync package.json version with release tag
+        run: |
+          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          npm version "${TAG#v}" --no-git-tag-version --allow-same-version
+
+      - name: Publish to npm
+        run: |
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            npm publish --tag beta
+          else
+            npm publish
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/android/src/main/java/com/bearblock/visioncameraocr/visioncameraocr/OcrFrameProcessorPlugin.kt
+++ b/android/src/main/java/com/bearblock/visioncameraocr/visioncameraocr/OcrFrameProcessorPlugin.kt
@@ -18,7 +18,7 @@ import java.util.HashMap
 
 class OcrFrameProcessorPlugin(
   proxy: VisionCameraProxy,
-  options: Map<String, Any>?
+  private val options: Map<String, Any>?
 ) : FrameProcessorPlugin() {
 
   private val recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish.yml`: publishes to npm when a GitHub release is published.
- Syncs `package.json` version to the release tag before publishing.
- Publishes with the `beta` npm dist-tag when the release is marked as a pre-release, otherwise `latest`.
- Also supports manual `workflow_dispatch` with a `tag` input for re-running a publish if needed.
- Requires the `NPM_TOKEN` repository secret (already configured) with publish access to `@bear-block/vision-camera-ocr`.

## Test plan
- [ ] After merge, publish a real (or draft→publish) GitHub release and confirm the `Publish to npm` job runs and succeeds.
- [ ] Verify the published npm version matches the release tag and lands on the correct dist-tag (`latest` vs `beta`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01HYY4YSxCBLwZaLQKZVRUuZ)_