### PR TITLE
fix(ci): stop release notes from being shell-interpreted

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,15 @@ jobs:
           ref: ${{ inputs.version && inputs.base_ref || steps.vars.outputs.tag }}
           fetch-depth: 0
 
+      - name: Write release notes
+        if: inputs.version != ''
+        env:
+          NOTES: ${{ inputs.notes }}
+        run: |
+          cat > "$RUNNER_TEMP/release-notes.md" <<'RELEASE_NOTES_EOF'
+          ${{ inputs.notes }}
+          RELEASE_NOTES_EOF
+
       - name: Create GitHub Release
         if: inputs.version != ''
         env:
@@ -55,7 +64,7 @@ jobs:
           gh release create "${{ steps.vars.outputs.tag }}" \
             --target "${{ inputs.base_ref }}" \
             --title "${{ steps.vars.outputs.tag }}" \
-            --notes "${{ inputs.notes }}" \
+            --notes-file "$RUNNER_TEMP/release-notes.md" \
             $( [ "${{ inputs.prerelease }}" = "true" ] && echo --prerelease )
 
       - name: Setup Node.js


### PR DESCRIPTION
## Summary
- `gh release create --notes "${{ inputs.notes }}"` let backticks/`$()` in the markdown notes get interpreted by bash before `gh` ever saw the string, corrupting the `v4.0.2` release body with leaked command output.
- Now writes the notes to a file via a quoted heredoc (`<<'RELEASE_NOTES_EOF'`, no shell expansion) and passes `--notes-file` instead.

## Test plan
- [ ] Dispatch a release with notes containing backticks/markdown code spans and confirm the release body renders correctly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HYY4YSxCBLwZaLQKZVRUuZ)_