### PR TITLE
ci: enable CI on support/v5 and fix the failing tests it surfaced

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,23 @@
 name: CI
+
+# NOTE: there are deliberately no native build jobs here. The build-android /
+# build-ios jobs that used to live in this file came from the
+# react-native-builder-bob template and drive an `example/` app that this repo
+# does not have, so they could never pass (build-ios died on `cd example`, and
+# build-android only "passed" because turbo found no matching task).
+# Re-adding native compile coverage requires scaffolding an example app first —
+# android/build.gradle depends on project(':react-native-vision-camera'), which
+# only resolves via autolinking inside a real RN app.
+
 on:
   push:
     branches:
       - main
+      - support/v5
   pull_request:
     branches:
       - main
+      - support/v5
   merge_group:
     types:
       - checks_requested
@@ -49,123 +61,3 @@ jobs:
 
       - name: Build package
         run: yarn prepare
-
-  build-android:
-    runs-on: ubuntu-latest
-    env:
-      TURBO_CACHE_DIR: .turbo/android
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Cache turborepo for Android
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.TURBO_CACHE_DIR }}
-          key: ${{ runner.os }}-turborepo-android-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-turborepo-android-
-
-      - name: Check turborepo cache for Android
-        run: |
-          TURBO_CACHE_STATUS=$(node -p "($(yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}" --dry=json)).tasks.find(t => t.task === 'build:android').cache.status")
-
-          if [[ $TURBO_CACHE_STATUS == "HIT" ]]; then
-            echo "turbo_cache_hit=1" >> $GITHUB_ENV
-          fi
-
-      - name: Install JDK
-        if: env.turbo_cache_hit != 1
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-
-      - name: Finalize Android SDK
-        if: env.turbo_cache_hit != 1
-        run: |
-          /bin/bash -c "yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null"
-
-      - name: Cache Gradle
-        if: env.turbo_cache_hit != 1
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/wrapper
-            ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('example/android/gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Build example for Android
-        env:
-          JAVA_OPTS: "-XX:MaxHeapSize=6g"
-        run: |
-          yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}"
-
-  build-ios:
-    runs-on: macos-latest
-    env:
-      XCODE_VERSION: 16.2
-      TURBO_CACHE_DIR: .turbo/ios
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Cache turborepo for iOS
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.TURBO_CACHE_DIR }}
-          key: ${{ runner.os }}-turborepo-ios-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-turborepo-ios-
-
-      - name: Check turborepo cache for iOS
-        run: |
-          TURBO_CACHE_STATUS=$(node -p "($(yarn turbo run build:ios --cache-dir="${{ env.TURBO_CACHE_DIR }}" --dry=json)).tasks.find(t => t.task === 'build:ios').cache.status")
-
-          if [[ $TURBO_CACHE_STATUS == "HIT" ]]; then
-            echo "turbo_cache_hit=1" >> $GITHUB_ENV
-          fi
-
-      - name: Use appropriate Xcode version
-        if: env.turbo_cache_hit != 1
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ${{ env.XCODE_VERSION }}
-
-      - name: Restore cocoapods
-        if: env.turbo_cache_hit != 1
-        id: cocoapods-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            **/ios/Pods
-          key: ${{ runner.os }}-cocoapods-${{ hashFiles('example/ios/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cocoapods-
-
-      - name: Install cocoapods
-        if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit != 'true'
-        run: |
-          cd example
-          bundle install
-          bundle exec pod install --project-directory=ios
-
-      - name: Cache cocoapods
-        if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            **/ios/Pods
-          key: ${{ steps.cocoapods-cache.outputs.cache-key }}
-
-      - name: Build example for iOS
-        run: |
-          yarn turbo run build:ios --cache-dir="${{ env.TURBO_CACHE_DIR }}"

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -38,7 +38,7 @@ describe('@bear-block/vision-camera-ocr', () => {
       const processor = getMockProcessor();
       performOcr(12345, 1920, 1080, 'up');
       expect(processor.performOcr).toHaveBeenCalledWith(
-        12345,
+        BigInt(12345),
         1920,
         1080,
         'up',
@@ -57,7 +57,7 @@ describe('@bear-block/vision-camera-ocr', () => {
       };
       performOcr(12345, 1920, 1080, 'up', options);
       expect(processor.performOcr).toHaveBeenCalledWith(
-        12345,
+        BigInt(12345),
         1920,
         1080,
         'up',
@@ -106,7 +106,7 @@ describe('@bear-block/vision-camera-ocr', () => {
       const processor = getMockProcessor();
       performOcr(BigInt(12345), 1920, 1080, 'up');
       expect(processor.performOcr).toHaveBeenCalledWith(
-        12345,
+        BigInt(12345),
         1920,
         1080,
         'up',


### PR DESCRIPTION
## Summary
`support/v5` still carried the original `ci.yml`, which meant **CI has never run on this branch at all**:

- The trigger list only covered `main`, so pushes and PRs on `support/v5` never started a run. (Adding `support/v5` to the trigger list on `main` alone does not help — for `push` events GitHub reads the workflow file from the pushed branch.)
- It also still had the `build-android` / `build-ios` jobs, which drive an `example/` app that does not exist on this branch either, so they could never pass.

This brings the file in line with `main` (see #10).

## The failure it immediately caught
Turning CI on here surfaced a real, pre-existing break: **3 of 6 unit tests fail on `support/v5`.**

#4 correctly changed `performOcr` to pass `BigInt(bufferPointer)` instead of `Number(bufferPointer)` (pointer values can exceed the signed integer range), but the test assertions were never updated:

```
Expected: 12345, 1920, 1080, "up", false, false, "fast"
Received: 12345n, 1920, 1080, "up", false, false, "fast"
```

The source is right; the assertions were stale. Updated them to expect `BigInt(12345)`.

## Test plan
- [x] Ran the suite locally against this branch with the fix: **6 passed, 0 failed**.
- [ ] Confirm CI is green here — that it runs at all is the other half of the fix.
